### PR TITLE
キャンバスの横幅がはみ出る問題の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-  <div class="container-sm" id="container">
+  <div class="container-sm">
     <h1 class="display">番組終了画面生成器</h1>
     <hr>
 

--- a/sketch.js
+++ b/sketch.js
@@ -15,9 +15,13 @@ function setup() {
 
   pixelDensity(2.0);
   // container の横幅を取得する
-  var width = document.getElementById("container").clientWidth;
-  var c = createCanvas(width, width * 9 / 16);
-  c.parent(document.getElementById("canvas"));
+
+
+  var width_container = document.getElementById("canvas").clientWidth;
+  var mycanvas = createCanvas(width_container, width_container * 9 / 16);
+  mycanvas.parent("canvas");
+
+
 
   name = "IA";
   subject = "プロトタイピング基礎";
@@ -84,4 +88,9 @@ function setText() {
 
 function saveImage() {
   save("end.png");
+}
+
+function windowResized() {
+  var width_container = document.getElementById("canvas").clientWidth;
+  resizeCanvas(width_container, width_container * 9 / 16);
 }


### PR DESCRIPTION
原因わかりました．一個上のタグの横幅じゃなくて，直接canvasを入れているタグの横幅を取得することで精確な横幅にキャンバスを合わせることができました．マージお願いします．